### PR TITLE
单例控制及引入async/await,简化代码

### DIFF
--- a/src/ipcs/base/counter.js
+++ b/src/ipcs/base/counter.js
@@ -1,0 +1,22 @@
+/**
+ * Created by Luky on 2017/11/08.
+ */
+
+class Counter{
+    constructor(){
+        this.ref=0;
+    }
+    addReference(){
+        return ++this.ref;
+    }
+    get inReference(){
+        return 0!==this.ref;
+    }
+    release(){
+        this.ref=Math.max(0,this.ref-1);
+        return this.ref===0;
+    }
+
+}
+
+exports=module.exports=Counter;

--- a/src/ipcs/base/ptz.js
+++ b/src/ipcs/base/ptz.js
@@ -1,9 +1,10 @@
 /**
  * Created by Luky on 2017/7/5.
  */
-let _=require('lodash');
-let EventEmitter=require('events').EventEmitter;
-let assert=require('assert');
+const _=require('lodash');
+const EventEmitter=require('events').EventEmitter;
+const assert=require('assert');
+const Counter=require('./counter');
 
 const _d={
     'top':1,'down':2,'left':4,'right':8,
@@ -14,6 +15,7 @@ class PTZ extends  EventEmitter{
     constructor(){
         super();
         this.options={};
+        this._conn_counter=new Counter();
     }
     static get Directions(){
         return _d;
@@ -25,28 +27,45 @@ class PTZ extends  EventEmitter{
     }
     get supportPTZ(){return true;}
     get config(){return this.options;}
-    get isConnected(){throw new Error('未实现函数isConnect');}
-    connect(){throw new Error('未实现函数connect');}
-    disConnect(){throw new Error('未实现函数disConnect');}
-    zoomAdd(stop) {throw new Error('未实现函数zoomAdd');}
-    zoomDec(stop) {throw new Error('未实现函数zoomDec');}
+    setConnected(){
+        assert.ok(!this._conn_counter.inReference);
+        this._conn_counter.addReference();
+    }
+    get isConnected(){return this._conn_counter.inReference}
+    async connect(){
+        if(this.isConnected) {
+            this._conn_counter.addReference();
+            return;
+        }
+        await this._connect();
+    }
+    async disConnect(){
+        if(this._conn_counter.release()){
+          await this._disConnect();
+        }
+    }
+    async _connect(){throw new Error('未实现函数_connect');}
+    async _disConnect(){throw new Error('未实现函数_disConnect');}
+    async zoomAdd(stop) {throw new Error('未实现函数zoomAdd');}
+    async zoomDec(stop) {throw new Error('未实现函数zoomDec');}
     //focusAuto() {throw new Error('未实现函数focusAuto');}
-    focusAdd(stop) {throw new Error('未实现函数focusAdd');}
-    focusDec(stop) {throw new Error('未实现函数focusDec');}
+    async focusAdd(stop) {throw new Error('未实现函数focusAdd');}
+    async focusDec(stop) {throw new Error('未实现函数focusDec');}
     //focusAuto() {throw new Error('未实现函数focusAuto');}
-    apertureAdd(stop) {throw new Error('未实现函数apertureAdd');}
-    apertureDec(stop) {throw new Error('未实现函数apertureDec');}
-    move(direction,stop){throw new Error('未实现函数move');}
-    moveToPoint(x,y,z){throw new Error('未实现函数moveToPoint');}
-    ptzStop(){throw new Error('未实现函数ptzStop');}
-    setPreset(caption){throw new Error('未实现函数setPreset');}
-    removePreset(preset){throw new Error('未实现函数removePreset');}
+    async apertureAdd(stop) {throw new Error('未实现函数apertureAdd');}
+    async apertureDec(stop) {throw new Error('未实现函数apertureDec');}
+    async move(direction,stop){throw new Error('未实现函数move');}
+    async moveToPoint(x,y,z){throw new Error('未实现函数moveToPoint');}
+    async ptzStop(){throw new Error('未实现函数ptzStop');}
+    //暂时不用预置点
+    //async setPreset(caption){throw new Error('未实现函数setPreset');}
+    //async removePreset(preset){throw new Error('未实现函数removePreset');}
     //移动到对应名称的预置点
-    moveToPreset(name){throw new Error('未实现函数moveToPreset');}
+    //async moveToPreset(name){throw new Error('未实现函数moveToPreset');}
     //移除对应名称的预置点
     //以下两个方法用于自动分配预置点和获取当前云台位置，各函数执行实现即可
     //getPresets(){throw new Error('未实现函数getPresets');}
-    getPoint(){throw new Error('未实现函数getPoint');}
+    async getPoint(){throw new Error('未实现函数getPoint');}
 }
 
 exports=module.exports=PTZ;


### PR DESCRIPTION
由于IPC控制为单个IPC单个实例，增加连接、直播、通话的计数控制，单个实例单次链接视频和通话。以及引入async/await,简化代码